### PR TITLE
Locking

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func getPage(w http.ResponseWriter, r *http.Request) {
 	edit := r.FormValue("edit")
 
 	s := &store{base: pageStore}
-	page := &Page{PageId: pageId, Store: s}
+	page := NewPage(pageId, s)
 	err = page.read()
 
 	// If we tried to get the page and it is not there, create
@@ -99,7 +99,8 @@ func setPage(w http.ResponseWriter, r *http.Request) {
 		delPage(w, r)
 	} else {
 		s := &store{base: pageStore}
-		page := &Page{PageId: pageId, Content: content, Store: s}
+		page := NewPage(pageId, s)
+		page.Content = content
 		err = page.save()
 		check(err)
 		http.Redirect(w, r, fmt.Sprintf("/p/%s", pageId), http.StatusSeeOther)
@@ -109,7 +110,7 @@ func setPage(w http.ResponseWriter, r *http.Request) {
 func delPage(w http.ResponseWriter, r *http.Request) {
 	pageId := chi.URLParam(r, "pageId")
 	s := &store{base: pageStore}
-	page := &Page{PageId: pageId, Store: s}
+	page := NewPage(pageId, s)
 	err := page.del()
 	check(err)
 	http.Redirect(w, r, fmt.Sprintf("/p/%s", pageId), http.StatusSeeOther)

--- a/page_test.go
+++ b/page_test.go
@@ -6,7 +6,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestTwoStores(t *testing.T) {
@@ -48,5 +50,71 @@ func TestTwoStores(t *testing.T) {
 	}
 	if string(content2) != "2" {
 		t.Errorf("content2 should contain 2 but has %s", content2)
+	}
+}
+
+func TestPageMutex(t *testing.T) {
+	s := &store{base: "."}
+	p1 := NewPage("1", s)
+	p1.Content = "1"
+	p2 := NewPage("1", s)
+	p2.Content = "2"
+	p3 := NewPage("1", s)
+	p3.Content = "3"
+
+	c := make(chan string, 1)
+	go func() {
+		pageLockMutex.Lock()
+		p1Lock, ok := pageLocks[p1.PageId]
+		if !ok {
+			p1Lock = &sync.RWMutex{}
+			pageLocks[p1.PageId] = p1Lock
+		}
+		p1Lock.Lock()
+		pageLockMutex.Unlock()
+		c <- "p1 locked"
+	}()
+
+	go func() {
+		// make sure p1 goes first
+		time.Sleep(5 * time.Millisecond)
+		pageLockMutex.Lock()
+		p2Lock, ok := pageLocks[p2.PageId]
+		if !ok {
+			p2Lock = &sync.RWMutex{}
+			pageLocks[p2.PageId] = p2Lock
+		}
+		p2Lock.Lock()
+		pageLockMutex.Unlock()
+		c <- "p2 locked"
+	}()
+
+	p1Locked := false
+	p2Locked := false
+
+outer:
+	for {
+		select {
+		case res := <-c:
+			t.Log("res", res)
+			if res == "p1 locked" {
+				p1Locked = true
+			}
+			if res == "p2 locked" {
+				p2Locked = true
+			}
+
+		case <-time.After(25 * time.Millisecond):
+			break outer
+		}
+	}
+
+	if p2Locked {
+		t.Log("p2 locked when it should not have")
+		t.Fail()
+	}
+	if !p1Locked {
+		t.Log("p1 never locked")
+		t.Fail()
 	}
 }


### PR DESCRIPTION
This uses a map of sync.RWMutex, keyed by page id, with the entire map guarded by its own Mutex. This means that a page file can be read by multiple readers, but not while it is being written and only one writer may write at a time.

This is a messy solution that will need to change if/when revisions or git-like storage happens: the lock prevents concurrent writes, but does nothing to prevent the lost update problem.

The reason for doing it at all, knowing that it will likely go away, was to get a better sense of how named mutexes could be made to work. The test added to page_test gives an example of concurrency and blocking.
    
